### PR TITLE
Added logging for the convenience

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -102,6 +102,8 @@ if __name__ == '__main__':
         parser.add_handler(JSONWriter(output_path))
     elif file_extension == ".csv":
         parser.add_handler(CSVWriter(output_path))
+    else:
+        logger.info("Currently are only supported outpus to files with extension .json or .scv")
     parser.run()
 
     logger.info("finished running %s", program)

--- a/parser.py
+++ b/parser.py
@@ -103,7 +103,8 @@ if __name__ == '__main__':
     elif file_extension == ".csv":
         parser.add_handler(CSVWriter(output_path))
     else:
-        logger.info("Currently are only supported output files with extension .json or .scv")
+        logger.info("Currently are only supported output files with extension .json or .csv")
+        sys.exit(1)
     parser.run()
 
     logger.info("finished running %s", program)

--- a/parser.py
+++ b/parser.py
@@ -103,7 +103,7 @@ if __name__ == '__main__':
     elif file_extension == ".csv":
         parser.add_handler(CSVWriter(output_path))
     else:
-        logger.info("Currently are only supported outpus to files with extension .json or .scv")
+        logger.info("Currently are only supported output files with extension .json or .scv")
     parser.run()
 
     logger.info("finished running %s", program)


### PR DESCRIPTION
In case when there is used this library from command prompt there was no error message displayed when there was selected incompatible output file.

This PR will make command line usage more convenient. 