### PR TITLE
Processing older DMOZ dumps, various enhancements.

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -25,41 +25,55 @@ class DmozHandler(handler.ContentHandler):
     def __init__(self, handler):
         self._handler = handler
         self._current_page = ''
+        self._current_topic = ''
         self._capture_content = False
         self._current_content = {}
-        self._expect_end = False
+        self._capture_content_type = ''
 
     def startElement(self, name, attrs):
         if name == 'ExternalPage':
+            # starting an external page entry. Set scene for capturing content
             self._current_page = attrs['about']
             self._current_content = {}
         elif name in ['d:Title', 'd:Description', 'priority', 'topic']:
-            self._capture_content = True
             self._capture_content_type = name
+            self._current_content[self._capture_content_type] = ''
+            self._capture_content = True
+        elif name == 'Topic':
+            self._current_topic = attrs['r:id']
+            # Example of such a Topic entry:
+            #     < Topic r:id = "Top/Arts/Movies/Titles/1/10_Rillington_Place" >
+            #       < catid > 205108 < /catid >
+            #       < link r:resource = "http://us.imdb.com/Title?0066730" / >
+            #       < link r:resource = "http://www.britishhorrorfilms.co.uk/rillington.shtml" / >
+            #       < link r:resource = "http://www.shoestring.org/mmi_revs/10-rillington-place.html" / >
+            #       < link r:resource = "http://www.tvguide.com/movies/database/ShowMovie.asp?MI=22983" / >
+            #      < /Topic >
 
     def endElement(self, name):
-        # Make sure that the only thing after "topic" is "/ExternalPage"
-        if self._expect_end:
-            assert name == 'topic' or name == 'ExternalPage'
-            if name == 'ExternalPage':
-                self._expect_end = False
+        #if ending one of the supported blocks, end content capturing
+        if name in ['d:Title', 'd:Description', 'priority', 'topic']:
+            self._capture_content = False
+        # if ending an ExternalPage, write the current entry in our content handler
+        if name == 'ExternalPage':
+            # first, check if we read a topic in the current ExternalPage entry.
+            # older DMOZ dumps do not have this, so we will use the last Topic read
+            if not 'topic' in self._current_content.keys():
+                self._current_content['topic'] = self._current_topic
+            # now save
+            self._handler.page(self._current_page, self._current_content)
 
     def characters(self, content):
         if self._capture_content:
-            assert not self._expect_end
-            self._current_content[self._capture_content_type] = content
-            # print self._capture_content_type, self._current_content[self._capture_content_type]
-            if self._capture_content_type == "topic":
-                # This makes the assumption that "topic" is the last entity in each dmoz page:
-                #   <ExternalPage about="http://www.awn.com/">
-                #     <d:Title>Animation World Network</d:Title>
-                #     <d:Description>Provides information resources to the international animation community. Features include searchable database archives, monthly magazine, web animation guide, the Animation Village, discussion forums and other useful resources.</d:Description>
-                #     <priority>1</priority>
-                #     <topic>Top/Arts/Animation</topic>
-                #   </ExternalPage>
-                    self._handler.page(self._current_page, self._current_content)
-                    self._expect_end = True
-            self._capture_content = False
+            # this bit of dark magic is to address content coming in two separate waves
+            self._current_content[self._capture_content_type] = ''.join([self._current_content[self._capture_content_type], content.strip()])
+            # An example for an ExternalPage entry. Note that <topic> might be missing in older dumps
+            #   <ExternalPage about="http://www.awn.com/">
+            #     <d:Title>Animation World Network</d:Title>
+            #     <d:Description>Provides information resources to the international animation community. Features include searchable database archives, monthly magazine, web animation guide, the Animation Village, discussion forums and other useful resources.</d:Description>
+            #     <priority>1</priority>
+            #     <topic>Top/Arts/Animation</topic>
+            #   </ExternalPage>
 
     def endDocument(self):
         self._handler.finish()
@@ -97,10 +111,9 @@ if __name__ == '__main__':
     parser = DmozParser(input_path)
 
     foo, file_extension = os.path.splitext(output_path)
-    ## we ask directly for a bzipped2 file
-    if file_extension == ".bz2":
+    # in case we ask directly for a zipped file
+    if file_extension in [".bz2", ".gz"]:
         _, file_extension = os.path.splitext(foo)
-    print file_extension
 
     if file_extension == ".json":
         parser.add_handler(JSONWriter(output_path))

--- a/parser.py
+++ b/parser.py
@@ -96,7 +96,11 @@ if __name__ == '__main__':
 
     parser = DmozParser(input_path)
 
-    _, file_extension = os.path.splitext(output_path)
+    foo, file_extension = os.path.splitext(output_path)
+    ## we ask directly for a bzipped2 file
+    if file_extension == ".bz2":
+        _, file_extension = os.path.splitext(foo)
+    print file_extension
 
     if file_extension == ".json":
         parser.add_handler(JSONWriter(output_path))


### PR DESCRIPTION
 List of bugs and enhancements:
- removed constraint that ExternalPage must contains "topic" and that it is last in the block;
- added compatibility with older dumps, which do not contains "topic" in "ExternalPage";
- solved bug of truncated content for long descriptions;
- added support for saving directly into compressed format: .csv.bz2 or .json.bz2 .
